### PR TITLE
Add WASM API and Embedder Builtins to V8

### DIFF
--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -1970,6 +1970,7 @@ v8_source_set("v8_base_without_compiler") {
     "include/v8-testing.h",
     "include/v8-util.h",
     "include/v8-wasm-trap-handler-posix.h",
+    "include/v8-wasm.h"
     "include/v8.h",
     "include/v8config.h",
     "src/api/api-arguments-inl.h",
@@ -1977,6 +1978,8 @@ v8_source_set("v8_base_without_compiler") {
     "src/api/api-arguments.h",
     "src/api/api-natives.cc",
     "src/api/api-natives.h",
+    "src/api/api-wasm.cc",
+    "src/api/api-wasm.h",
     "src/api/api.cc",
     "src/api/api.h",
     "src/asmjs/asm-js.cc",

--- a/deps/v8/include/v8-wasm.h
+++ b/deps/v8/include/v8-wasm.h
@@ -13,13 +13,12 @@
 namespace v8 {
 namespace wasm {
 
-#define PAGE_SIZE 0x10000
-
 class V8_EXPORT Memory {
  private:
   size_t pages_;
   uint8_t* data_;
  public:
+  static const int PAGE_SIZE = 0x10000;
   Memory(size_t pages, uint8_t* data);
   Memory(const Memory& memory);
   size_t size();

--- a/deps/v8/include/v8-wasm.h
+++ b/deps/v8/include/v8-wasm.h
@@ -1,0 +1,123 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef INCLUDE_V8_WASM_H_
+#define INCLUDE_V8_WASM_H_
+
+#include <cassert>
+#include <cstdint>
+#include <cstddef>
+#include "v8.h"
+
+namespace v8 {
+namespace wasm {
+
+#define PAGE_SIZE 0x10000
+
+class V8_EXPORT Memory {
+ private:
+  size_t pages_;
+  uint8_t* data_;
+ public:
+  Memory(size_t pages, uint8_t* data);
+  Memory(const Memory& memory);
+  size_t size();
+  size_t pages();
+  uint8_t* data();
+};
+
+class V8_EXPORT Table {
+ private:
+  void* tableObject_;
+ public:
+  Table(void* tableObject);
+  Table(const Table& table);
+  ~Table();
+  MaybeLocal<Function> get(int index) const;
+};
+
+class V8_EXPORT Context {
+ public:
+  Context(Memory* memory, Table* table);
+  Context(Memory* memory, Table* table, v8::Isolate* isolate);
+  Context(const Context& context);
+  ~Context();
+  Memory* memory;
+  Table* table;
+  v8::Isolate* isolate;
+};
+
+enum V8_EXPORT ValKind : uint8_t {
+  I32,
+  I64,
+  F32,
+  F64,
+  ANYREF = 128,
+  FUNCREF
+};
+
+// TODO(ohadrau): Should we enforce Ref ownership like the C API?
+class V8_EXPORT Val {
+ private:
+  ValKind kind_;
+  union value {
+    int32_t i32;
+    int64_t i64;
+    float f32;
+    double f64;
+    void* ref;
+  } value_;
+
+  Val(ValKind kind, value value);
+
+ public:
+  Val();
+  Val(Val&& val);
+  explicit Val(int32_t i);
+  explicit Val(int64_t i);
+  explicit Val(float i);
+  explicit Val(double i);
+  explicit Val(void* r);
+
+  Val& operator=(Val&&);
+
+  ValKind kind() const;
+  int32_t i32() const;
+  int64_t i64() const;
+  float f32() const;
+  double f64() const;
+  void* ref() const;
+};
+
+class V8_EXPORT FuncType {
+ private:
+  std::vector<ValKind> params_, results_;
+ public:
+  FuncType(std::vector<ValKind> params, std::vector<ValKind> results);
+
+  std::vector<ValKind> params() const;
+  std::vector<ValKind> results() const;
+};
+
+class V8_EXPORT Func {
+ public:
+  using callbackType = void (*)(const Context*, const Val[], Val[]);
+  Func(const FuncType, callbackType);
+
+  const FuncType type();
+  callbackType callback();
+ private:
+  const FuncType type_;
+  callbackType callback_;
+};
+
+void RegisterEmbedderBuiltin(Isolate* isolate,
+                             const char* module_name,
+                             const char* name,
+                             Func import);
+
+}  // namespace wasm
+}  // namespace v8
+
+#endif  // INCLUDE_V8_WASM_H_

--- a/deps/v8/src/api/api-wasm.cc
+++ b/deps/v8/src/api/api-wasm.cc
@@ -1,0 +1,317 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/api/api-wasm.h"
+#include "src/base/memory.h"
+#include "src/common/globals.h"
+#include "src/api/api-inl.h"
+#include "src/objects/contexts.h"
+#include "src/objects/lookup.h"
+#include "src/execution/isolate.h"
+
+#define IGNORE(X) ((void) (X))
+
+namespace b = v8::base;
+namespace i = v8::internal;
+
+namespace v8 {
+namespace wasm {
+
+Memory::Memory(size_t pages, uint8_t* data) : pages_(pages), data_(data) {}
+Memory::Memory(const Memory& memory)
+    : pages_(memory.pages_), data_(memory.data_) {}
+size_t Memory::size() { return pages_ * PAGE_SIZE; }
+size_t Memory::pages() { return pages_; }
+uint8_t* Memory::data() { return data_; }
+
+Table::Table(void* tableObject) {
+  tableObject_ = (void*) new i::WasmTableObject(
+      *(i::WasmTableObject*) tableObject);
+}
+Table::Table(const Table& table) {
+  tableObject_ = (void*) new i::WasmTableObject(
+      *(i::WasmTableObject*) table.tableObject_);
+}
+Table::~Table() { delete tableObject_; }
+MaybeLocal<Function> Table::get(int index) const {
+  i::Isolate* i_isolate = i::Isolate::TryGetCurrent();
+  i::WasmTableObject* table = (i::WasmTableObject*) tableObject_;
+  i::Handle<i::WasmTableObject> tableHandle =
+      i::Handle<i::WasmTableObject>(*table, i_isolate);
+  i::Handle<i::Object> entry =
+      i::WasmTableObject::Get(i_isolate, tableHandle, index);
+
+  // TODO(ohadrau): Assumes this is a FUNCREF table
+  if (i::WasmExportedFunction::IsWasmExportedFunction(*entry) ||
+      i::WasmCapiFunction::IsWasmCapiFunction(*entry)) {
+    return Utils::ToLocal(i::Handle<i::JSFunction>::cast(entry));
+  } else {
+    return MaybeLocal<Function>();
+  }
+}
+
+Context::Context(Memory* memory, Table* table)
+    : isolate(Isolate::GetCurrent()), memory(memory), table(table) {}
+Context::Context(Memory* memory, Table* table, Isolate* isolate)
+    : isolate(isolate), memory(memory), table(table) {}
+Context::Context(const Context& context)
+    : isolate(context.isolate) {
+  this->memory = new Memory(*context.memory);
+  this->table = new Table(*context.table);
+}
+Context::~Context() {
+  delete this->memory;
+  delete this->table;
+}
+
+Val::Val(ValKind kind, value value) : kind_(kind), value_(value) {}
+
+Val::Val() : kind_(ANYREF) { value_.ref = nullptr; }
+Val::Val(Val&& val) : Val(val.kind_, val.value_) {
+}
+
+Val::Val(int32_t i) : kind_(I32) { value_.i32 = i; }
+Val::Val(int64_t i) : kind_(I64) { value_.i64 = i; }
+Val::Val(float i) : kind_(F32) { value_.f32 = i; }
+Val::Val(double i) : kind_(F64) { value_.f64 = i; }
+Val::Val(void* r) : kind_(ANYREF) { value_.ref = r; }
+
+Val& Val::operator=(Val&& val) {
+  kind_ = val.kind_;
+  value_ = val.value_;
+  return *this;
+}
+
+ValKind Val::kind() const { return kind_; }
+int32_t Val::i32() const { assert(kind_ == I32); return value_.i32; }
+int64_t Val::i64() const { assert(kind_ == I64); return value_.i64; }
+float Val::f32() const { assert(kind_ == F32); return value_.f32; }
+double Val::f64() const { assert(kind_ == F64); return value_.f64; }
+void* Val::ref() const {
+  assert(kind_ == ANYREF || kind_ == FUNCREF);
+  return value_.ref;
+}
+
+FuncType::FuncType(
+  std::vector<ValKind> params, std::vector<ValKind> results
+) : params_(params), results_(results) {}
+
+std::vector<ValKind> FuncType::params() const { return params_; }
+std::vector<ValKind> FuncType::results() const { return results_; }
+
+Func::Func(const FuncType funcType, callbackType cb) :
+  type_(funcType),
+  callback_(cb) {}
+
+const FuncType Func::type() {
+  return type_;
+}
+
+Func::callbackType Func::callback() {
+  return callback_;
+}
+
+i::wasm::ValueType valkind_to_v8(ValKind type) {
+  switch (type) {
+    case I32:
+      return i::wasm::kWasmI32;
+    case I64:
+      return i::wasm::kWasmI64;
+    case F32:
+      return i::wasm::kWasmF32;
+    case F64:
+      return i::wasm::kWasmF64;
+    default:
+      // TODO(wasm+): support new value types
+      UNREACHABLE();
+  }
+}
+
+// TODO(ohadrau): Clean up so that we're not maintaining 2 copies of this
+// Use an invalid type as a marker separating params and results.
+const i::wasm::ValueType kMarker = i::wasm::kWasmStmt;
+
+i::Handle<i::PodArray<i::wasm::ValueType>> Serialize(
+    i::Isolate* isolate, const FuncType type) {
+  int sig_size =
+      static_cast<int>(type.params().size() + type.results().size() + 1);
+  i::Handle<i::PodArray<i::wasm::ValueType>> sig =
+      i::PodArray<i::wasm::ValueType>::New(isolate, sig_size,
+                                           i::AllocationType::kOld);
+  int index = 0;
+  // TODO(jkummerow): Consider making vec<> range-based for-iterable.
+  for (size_t i = 0; i < type.results().size(); i++) {
+    sig->set(index++, valkind_to_v8(type.results()[i]));
+  }
+  // {sig->set} needs to take the address of its second parameter,
+  // so we can't pass in the static const kMarker directly.
+  i::wasm::ValueType marker = kMarker;
+  sig->set(index++, marker);
+  for (size_t i = 0; i < type.params().size(); i++) {
+    sig->set(index++, valkind_to_v8(type.params()[i]));
+  }
+  return sig;
+}
+
+FuncData::FuncData(i::Isolate* isolate, const FuncType type)
+    : isolate(isolate) {
+  param_count = type.params().size();
+  result_count = type.results().size();
+  serialized_sig = *Serialize(isolate, type);
+}
+
+i::Address FuncData::v8_callback(
+  void* data, size_t memoryPages, uint8_t* memoryBase,
+  i::WasmTableObject table, i::Address argv
+) {
+  FuncData* self = reinterpret_cast<FuncData*>(data);
+  i::Isolate* isolate = self->isolate;
+  HandleScope scope(reinterpret_cast<v8::Isolate*>(isolate));
+
+  int num_param_types = self->param_count;
+  int num_result_types = self->result_count;
+
+  std::unique_ptr<Val[]> params(new Val[num_param_types]);
+  std::unique_ptr<Val[]> results(new Val[num_result_types]);
+  i::Address p = argv;
+  for (int i = 0; i < num_param_types; ++i) {
+    switch (self->serialized_sig.get(i + num_result_types + 1)) {
+      case i::wasm::kWasmI32:
+        params[i] = Val(b::ReadUnalignedValue<int32_t>(p));
+        p += 4;
+        break;
+      case i::wasm::kWasmI64:
+        params[i] = Val(b::ReadUnalignedValue<int64_t>(p));
+        p += 8;
+        break;
+      case i::wasm::kWasmF32:
+        params[i] = Val(b::ReadUnalignedValue<float>(p));
+        p += 4;
+        break;
+      case i::wasm::kWasmF64:
+        params[i] = Val(b::ReadUnalignedValue<double>(p));
+        p += 8;
+        break;
+      case i::wasm::kWasmAnyRef:
+      case i::wasm::kWasmAnyFunc: {
+        i::Address raw = b::ReadUnalignedValue<i::Address>(p);
+        p += sizeof(raw);
+        if (raw == i::kNullAddress) {
+          params[i] = Val(nullptr);
+        } else {
+          i::JSReceiver raw_obj = i::JSReceiver::cast(i::Object(raw));
+          i::Handle<i::JSReceiver> obj(raw_obj, raw_obj.GetIsolate());
+          params[i] = Val(reinterpret_cast<void*>(obj->address()));
+        }
+        break;
+      }
+    }
+  }
+
+  Memory* memory = new Memory(memoryPages, memoryBase);
+  Table* apiTable = new Table(&table);
+  const Context* context = new Context(memory, apiTable);
+
+  self->callback(context, params.get(), results.get());
+
+  delete context;
+
+  if (isolate->has_scheduled_exception()) {
+    isolate->PromoteScheduledException();
+  }
+  if (isolate->has_pending_exception()) {
+    i::Object ex = isolate->pending_exception();
+    isolate->clear_pending_exception();
+    return ex.ptr();
+  }
+
+  p = argv;
+  for (int i = 0; i < num_result_types; ++i) {
+    switch (self->serialized_sig.get(i)) {
+      case i::wasm::kWasmI32:
+        b::WriteUnalignedValue(p, results[i].i32());
+        p += 4;
+        break;
+      case i::wasm::kWasmI64:
+        b::WriteUnalignedValue(p, results[i].i64());
+        p += 8;
+        break;
+      case i::wasm::kWasmF32:
+        b::WriteUnalignedValue(p, results[i].f32());
+        p += 4;
+        break;
+      case i::wasm::kWasmF64:
+        b::WriteUnalignedValue(p, results[i].f64());
+        p += 8;
+        break;
+      case i::wasm::kWasmAnyRef:
+      case i::wasm::kWasmAnyFunc: {
+        if (results[i].ref() == nullptr) {
+          b::WriteUnalignedValue(p, i::kNullAddress);
+        } else {
+          b::WriteUnalignedValue(p, results[i].ref());
+        }
+        p += sizeof(i::Address);
+        break;
+      }
+    }
+  }
+  return i::kNullAddress;
+}
+
+void RegisterEmbedderBuiltin(Isolate* isolate,
+                             const char* module_name,
+                             const char* name,
+                             Func import) {
+  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
+  i::HandleScope handle_scope(i_isolate);
+
+  Eternal<i::JSObject> imports = i_isolate->wasm_native_imports();
+  if (imports.IsEmpty()) {
+    i::Handle<i::JSObject> handle =
+        i_isolate->factory()->NewJSObject(i_isolate->object_function());
+    Local<i::JSObject> local =
+        Utils::Convert<i::JSObject, i::JSObject>(handle);
+    imports.Set(isolate, local);
+  }
+
+  Local<i::JSObject> imports_local = imports.Get(isolate);
+  i::Handle<i::JSObject> imports_handle =
+      i::Handle<i::JSObject>(reinterpret_cast<i::Address*>(*imports_local));
+
+  i::Handle<i::String> module_str =
+      i_isolate->factory()->NewStringFromAsciiChecked(module_name);
+  i::Handle<i::String> name_str =
+      i_isolate->factory()->NewStringFromAsciiChecked(name);
+
+  i::Handle<i::JSObject> module_obj;
+  i::LookupIterator module_it(i_isolate, imports_handle, module_str,
+                              i::LookupIterator::OWN_SKIP_INTERCEPTOR);
+  if (i::JSObject::HasProperty(&module_it).ToChecked()) {
+    module_obj = i::Handle<i::JSObject>::cast(
+        i::Object::GetProperty(&module_it).ToHandleChecked());
+  } else {
+    module_obj =
+        i_isolate->factory()->NewJSObject(i_isolate->object_function());
+    IGNORE(i::Object::SetProperty(i_isolate, imports_handle,
+                                  module_str, module_obj));
+  }
+
+  FuncData* data = new FuncData(i_isolate, import.type());
+  data->callback = import.callback();
+  i::Handle<i::PodArray<i::wasm::ValueType>> serialized_sig(
+      data->serialized_sig, i_isolate);
+  i::Handle<i::WasmCapiFunction> callback =
+      i::WasmCapiFunction::New(
+        i_isolate, reinterpret_cast<i::Address>(&FuncData::v8_callback),
+        data, serialized_sig);
+  IGNORE(i::Object::SetProperty(i_isolate, module_obj, name_str, callback));
+
+  i_isolate->set_wasm_native_imports(imports);
+}
+
+}  // namespace wasm
+}  // namespace v8
+
+#undef IGNORE

--- a/deps/v8/src/api/api-wasm.cc
+++ b/deps/v8/src/api/api-wasm.cc
@@ -26,14 +26,16 @@ size_t Memory::pages() { return pages_; }
 uint8_t* Memory::data() { return data_; }
 
 Table::Table(void* tableObject) {
-  tableObject_ = (void*) new i::WasmTableObject(
-      *(i::WasmTableObject*) tableObject);
+  i::WasmTableObject* actualTable =
+      reinterpret_cast<i::WasmTableObject*>(tableObject);
+  tableObject_ = (void*) new i::WasmTableObject(*actualTable);
 }
 Table::Table(const Table& table) {
-  tableObject_ = (void*) new i::WasmTableObject(
-      *(i::WasmTableObject*) table.tableObject_);
+  i::WasmTableObject* actualTable =
+      reinterpret_cast<i::WasmTableObject*>(table.tableObject_);
+  tableObject_ = (void*) new i::WasmTableObject(*actualTable);
 }
-Table::~Table() { delete tableObject_; }
+Table::~Table() { delete reinterpret_cast<i::WasmTableObject*>(tableObject_); }
 MaybeLocal<Function> Table::get(int index) const {
   i::Isolate* i_isolate = i::Isolate::TryGetCurrent();
   i::WasmTableObject* table = (i::WasmTableObject*) tableObject_;
@@ -129,6 +131,7 @@ i::wasm::ValueType valkind_to_v8(ValKind type) {
 }
 
 // TODO(ohadrau): Clean up so that we're not maintaining 2 copies of this
+// Taken from c-api.cc -- SignatureHelper::Serialize
 // Use an invalid type as a marker separating params and results.
 const i::wasm::ValueType kMarker = i::wasm::kWasmStmt;
 

--- a/deps/v8/src/api/api-wasm.h
+++ b/deps/v8/src/api/api-wasm.h
@@ -1,0 +1,32 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_API_API_WASM_H_
+#define V8_API_API_WASM_H_
+
+#include "include/v8-wasm.h"
+#include "src/objects/fixed-array.h"
+#include "src/wasm/value-type.h"
+#include "src/wasm/wasm-objects.h"
+
+namespace v8 {
+namespace wasm {
+
+struct FuncData {
+  v8::internal::Isolate* isolate;
+  v8::internal::PodArray<v8::internal::wasm::ValueType> serialized_sig;
+  int param_count, result_count;
+  Func::callbackType callback;
+
+  FuncData(v8::internal::Isolate* isolate, const FuncType type);
+
+  static v8::internal::Address v8_callback(
+    void* data, size_t memoryPages, uint8_t* memoryBase,
+    i::WasmTableObject table, i::Address argv);
+};
+
+}  // namespace wasm
+}  // namespace v8
+
+#endif  // V8_API_API_WASM_H_

--- a/deps/v8/src/compiler/wasm-compiler.h
+++ b/deps/v8/src/compiler/wasm-compiler.h
@@ -122,7 +122,8 @@ V8_EXPORT_PRIVATE wasm::WasmCompilationResult CompileWasmImportCallWrapper(
 // Compiles a host call wrapper, which allows WASM to call host functions.
 wasm::WasmCode* CompileWasmCapiCallWrapper(wasm::WasmEngine*,
                                            wasm::NativeModule*,
-                                           wasm::FunctionSig*, Address address);
+                                           wasm::FunctionSig*,
+                                           Address address);
 
 // Returns an OptimizedCompilationJob object for a JS to Wasm wrapper.
 std::unique_ptr<OptimizedCompilationJob> NewJSToWasmCompilationJob(

--- a/deps/v8/src/execution/isolate.h
+++ b/deps/v8/src/execution/isolate.h
@@ -404,6 +404,7 @@ using DebugObjectCache = std::vector<Handle<HeapObject>>;
   V(ExtensionCallback, wasm_instance_callback, &NoExtension)                   \
   V(WasmStreamingCallback, wasm_streaming_callback, nullptr)                   \
   V(WasmThreadsEnabledCallback, wasm_threads_enabled_callback, nullptr)        \
+  V(Eternal<JSObject>, wasm_native_imports, Eternal<JSObject>())               \
   /* State for Relocatable. */                                                 \
   V(Relocatable*, relocatable_top, nullptr)                                    \
   V(DebugObjectCache*, string_stream_debug_object_cache, nullptr)              \

--- a/deps/v8/src/wasm/c-api.cc
+++ b/deps/v8/src/wasm/c-api.cc
@@ -1498,7 +1498,9 @@ struct FuncData {
     if (finalizer) (*finalizer)(env);
   }
 
-  static i::Address v8_callback(void* data, i::Address argv);
+  static i::Address v8_callback(void* data, size_t memoryPages,
+                                uint8_t* memoryBase, i::WasmTableObject table,
+                                i::Address argv);
   static void finalize_func_data(void* data);
 };
 
@@ -1801,7 +1803,9 @@ auto Func::call(const Val args[], Val results[]) const -> own<Trap*> {
   return nullptr;
 }
 
-i::Address FuncData::v8_callback(void* data, i::Address argv) {
+i::Address FuncData::v8_callback(void* data, size_t memoryPages,
+                                 uint8_t* memoryBase, i::WasmTableObject table,
+                                 i::Address argv) {
   FuncData* self = reinterpret_cast<FuncData*>(data);
 
   const vec<ValType*>& param_types = self->type->params();

--- a/deps/v8/src/wasm/wasm-feature-flags.h
+++ b/deps/v8/src/wasm/wasm-feature-flags.h
@@ -29,5 +29,7 @@
   SEPARATOR                                                           \
   V(type_reflection, "wasm type reflection in JS", false)             \
   SEPARATOR                                                           \
-  V(compilation_hints, "compilation hints section", false)
+  V(compilation_hints, "compilation hints section", false)            \
+  SEPARATOR                                                           \
+  V(embedderBuiltins, "wasm embedder builtin functions", true)
 #endif  // V8_WASM_WASM_FEATURE_FLAGS_H_

--- a/deps/v8/src/wasm/wasm-js.cc
+++ b/deps/v8/src/wasm/wasm-js.cc
@@ -672,11 +672,6 @@ void WebAssemblyEmbedderBuiltins(
   HandleScope scope(isolate);
 
   ScheduledErrorThrower thrower(i_isolate, "WebAssembly.embedderBuiltins()");
-  /*v8::ReturnValue<v8::Value> return_value = args.GetReturnValue();
-
-  Eternal<i::JSObject> imports = i_isolate->wasm_native_imports();
-  Local<i::JSObject> result = imports.Get(isolate);
-  return_value.Set(Utils::ToLocal(result));*/
 
   v8::ReturnValue<v8::Value> return_value = args.GetReturnValue();
   Eternal<i::JSObject> imports = i_isolate->wasm_native_imports();


### PR DESCRIPTION
This commit adds a WebAssembly API to the V8 API. This enables the use and export of WASM values and functions from V8 API consumers. Specifically, this enables the use of many of the WASM C-API constructs alongside a normal V8 JavaScript engine. Additionally, this adds `WebAssembly.embedderBuiltins()`, a JS function that can return a set of builtin modules (for WASM programs) provided by the V8 embedder.

[Design Docs](https://docs.google.com/document/d/1yH7Bj9mjnsGcZMV03VgH7ldJ4o6sT7j0eOlYGTpMCSY/edit)

Main files are:
* `deps/v8/api/api-wasm.cc` -- Primary implementation of API additions
* `deps/v8/include/v8-wasm.h` -- Headers for new API

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
