### PR TITLE
Add WASM native module loader

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -95,6 +95,7 @@ if (isMainThread) {
 // Set up methods on the process object for all threads
 {
   process.dlopen = rawMethods.dlopen;
+  process.wasmOpen = rawMethods.wasmOpen;
   process.uptime = rawMethods.uptime;
 
   // TODO(joyeecheung): either remove them or make them public

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -808,6 +808,20 @@ Module._extensions['.json'] = function(module, filename) {
   }
 };
 
+Module._extensions['.node.wasm'] = function(module, filename) {
+  const content = fs.readFileSync(filename);
+  const mod = new WebAssembly.Module(content);
+  let imports = WebAssembly.embedderBuiltins();
+  // TODO(ohadrau): Load WASI
+  imports.wasi_unstable = {
+    fd_close: () => 0,
+    fd_write: () => 0,
+    fd_seek: () => 0,
+    fd_fdstat_get: () => 0
+  }
+  const instance = new WebAssembly.Instance(mod, imports);
+  return process.wasmOpen(module, instance.exports.main);
+}
 
 // Native extension for .node
 Module._extensions['.node'] = function(module, filename) {

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -29,7 +29,7 @@ const extensionFormatMap = {
   '.cjs': 'commonjs',
   '.js': 'module',
   '.json': 'json',
-  '.mjs': 'module'
+  '.mjs': 'module',
 };
 
 const legacyExtensionFormatMap = {
@@ -38,7 +38,8 @@ const legacyExtensionFormatMap = {
   '.js': 'commonjs',
   '.json': 'json',
   '.mjs': 'module',
-  '.node': 'commonjs'
+  '.node': 'commonjs',
+  '.node.wasm': 'commonjs'
 };
 
 if (experimentalWasmModules)

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -52,7 +52,8 @@ static const char* const EXTENSIONS[] = {
   ".cjs",
   ".js",
   ".json",
-  ".node"
+  ".node",
+  ".node.wasm"
 };
 
 ModuleWrap::ModuleWrap(Environment* env,
@@ -681,6 +682,9 @@ Maybe<URL> LegacyMainResolve(const URL& pjson_url,
     if (FileExists(guess = URL("./" + pcfg.main + ".node", pjson_url))) {
       return Just(guess);
     }
+    if (FileExists(guess = URL("./" + pcfg.main + ".node.wasm", pjson_url))) {
+      return Just(guess);
+    }
     if (FileExists(guess = URL("./" + pcfg.main + "/index.js", pjson_url))) {
       return Just(guess);
     }
@@ -689,6 +693,9 @@ Maybe<URL> LegacyMainResolve(const URL& pjson_url,
       return Just(guess);
     }
     if (FileExists(guess = URL("./" + pcfg.main + "/index.node", pjson_url))) {
+      return Just(guess);
+    }
+    if (FileExists(guess = URL("./" + pcfg.main + "/index.node.wasm", pjson_url))) {
       return Just(guess);
     }
     // Fallthrough.
@@ -701,6 +708,9 @@ Maybe<URL> LegacyMainResolve(const URL& pjson_url,
     return Just(guess);
   }
   if (FileExists(guess = URL("./index.node", pjson_url))) {
+    return Just(guess);
+  }
+  if (FileExists(guess = URL("./index.node.wasm", pjson_url))) {
     return Just(guess);
   }
   // Not found.

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -92,6 +92,7 @@ void RegisterBuiltinModules();
 void GetInternalBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetLinkedBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void DLOpen(const v8::FunctionCallbackInfo<v8::Value>& args);
+void WASMOpen(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 }  // namespace binding
 

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -433,6 +433,7 @@ static void InitializeProcessMethods(Local<Object> target,
 
   env->SetMethodNoSideEffect(target, "cwd", Cwd);
   env->SetMethod(target, "dlopen", binding::DLOpen);
+  env->SetMethod(target, "wasmOpen", binding::WASMOpen);
   env->SetMethod(target, "reallyExit", ReallyExit);
   env->SetMethodNoSideEffect(target, "uptime", Uptime);
   env->SetMethod(target, "patchProcessObject", PatchProcessObject);


### PR DESCRIPTION
This PR builds on #1 and #2, adding a loader for WASM native modules. This change is relatively simple and is mostly just some standard JS code to load a WASM module + a new function in the process module (`process.wasmOpen`) that mimics DLopen for WASM modules (loads functions exported through N-API).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
